### PR TITLE
Fix post creation validation and storage

### DIFF
--- a/api/post_create.php
+++ b/api/post_create.php
@@ -1,9 +1,9 @@
 <?php
 require __DIR__.'/api_bootstrap.php';
 $title = param('title'); $content = param('content'); $author = current_user() ?: 'anon';
-if($title===''||$content===''){ respond(['status'=>'error','message'=>'Title & content required'];; }
+if ($title === '' || $content === '') { respond(['status' => 'error', 'message' => 'Title & content required']); }
 $posts = read_json('posts.json'); if(!is_array($posts)) $posts=[];
-$posts.$posts[] = ['id'=>uniqid(), 'title'=>$title, 'content'=>$content, 'author'=>$author, 'created_at'=>date('c')];;
+$posts[] = ['id'=>uniqid(), 'title'=>$title, 'content'=>$content, 'author'=>$author, 'created_at'=>date('c')];
 
 write_json('posts.json',$posts);
 respond(['status'=>'ok','message'=>'Posted']);


### PR DESCRIPTION
## Summary
- fix empty title/content check for new posts
- correct posts array update

## Testing
- `php -l api/post_create.php`


------
https://chatgpt.com/codex/tasks/task_e_68a759f3ac80832fab3546d0eccf5c53