### PR TITLE
Add public users API and block direct data access

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,4 @@
-
 DirectoryIndex index.php
 RewriteEngine On
+RewriteRule ^data/ - [F,L]
 RewriteRule ^user/([A-Za-z0-9_\-]+)/?$ user.php?u=$1 [L,QSA]

--- a/api/users_public.php
+++ b/api/users_public.php
@@ -1,0 +1,15 @@
+<?php
+require __DIR__.'/api_bootstrap.php';
+$users = read_json('users.json');
+$safe = ['display_name','bio','avatar','twitch_channel','last_seen','live'];
+$public = [];
+foreach ($users as $u => $rec) {
+    $public[$u] = [];
+    foreach ($safe as $k) {
+        if (isset($rec[$k])) {
+            $public[$u][$k] = $rec[$k];
+        }
+    }
+}
+respond($public);
+?>

--- a/assets/js/live.js
+++ b/assets/js/live.js
@@ -13,12 +13,12 @@ document.getElementById('chatForm').addEventListener('submit', async (e)=>{
 });
 setInterval(refreshChat, 3000); document.addEventListener('DOMContentLoaded', refreshChat);
 
-// Load player's Twitch channel from profile via /data/users.json (if blocked, replace with API)
+// Load player's Twitch channel from profile via public API
 (async ()=>{
   try{
     const meRes = await fetch('/api/get_users_online.php'); const pres = await meRes.json();
     const me = pres.currentUser;
-    const users = await (await fetch('/data/users.json',{cache:'no-store'})).json();
+    const users = await (await fetch('/api/users_public.php',{cache:'no-store'})).json();
     const rec = me && users[me] ? users[me] : null;
     if(rec && rec.twitch_channel){
       document.getElementById('livePlayer').innerHTML = `<iframe src="https://player.twitch.tv/?channel=${rec.twitch_channel}&parent=${location.hostname}" allowfullscreen style="width:100%;height:100%;border:0"></iframe>`;

--- a/index.php
+++ b/index.php
@@ -39,7 +39,7 @@
 async function setupFeatured(){
   try{
     const res = await fetch('/api/get_users_online.php'); const data = await res.json();
-    const users = await (await fetch('/data/users.json',{cache:'no-store'})).json(); // if blocked, replace with API for this
+    const users = await (await fetch('/api/users_public.php',{cache:'no-store'})).json(); // fetch public user profiles
     let liveUser = (data.live||[])[0];
     if(liveUser && users[liveUser] && users[liveUser].twitch_channel){
       const ch = users[liveUser].twitch_channel;


### PR DESCRIPTION
## Summary
- Block direct HTTP access to the `data` directory via `.htaccess`
- Provide `api/users_public.php` exposing only safe user fields
- Update front-end scripts to query the new API instead of raw JSON

## Testing
- `php -l api/users_public.php`
- `php -l index.php`
- `node --check assets/js/live.js`


------
https://chatgpt.com/codex/tasks/task_e_68a759fdd864832f82871bc1c88d5be1