### PR TITLE
Add post and user post retrieval APIs and update views

### DIFF
--- a/api/post_get.php
+++ b/api/post_get.php
@@ -1,0 +1,8 @@
+<?php
+require __DIR__.'/api_bootstrap.php';
+$id = param('id'); if($id==='') respond(['status'=>'error','message'=>'id required']);
+$posts = read_json('posts.json'); $likes = read_json('likes.json');
+foreach($posts as $p){ if((string)$p['id']===(string)$id){ $pid=$p['id']; $p['likes']=isset($likes[$pid])?intval($likes[$pid]):0; respond($p); }
+}
+respond(['status'=>'error','message'=>'Not found']);
+?>

--- a/api/posts_by_user.php
+++ b/api/posts_by_user.php
@@ -1,0 +1,9 @@
+<?php
+require __DIR__.'/api_bootstrap.php';
+$u = strtolower(param('username')); $offset=max(0,intval(param('offset'))); $limit=min(60,max(1,intval(param('limit'))?:12));
+$posts = read_json('posts.json'); $likes = read_json('likes.json');
+$posts = array_values(array_filter($posts, function($p) use ($u){ return strtolower($p['author']??'')===$u; }));
+foreach($posts as &$p){ $pid=$p['id']; $p['likes']=isset($likes[$pid])?intval($likes[$pid]):0; } unset($p);
+usort($posts,function($a,$b){ return strcmp($b['created_at'],$a['created_at']); });
+respond(array_slice($posts,$offset,$limit));
+?>

--- a/post_view.php
+++ b/post_view.php
@@ -16,10 +16,9 @@
 const id = new URLSearchParams(location.search).get('id'); document.getElementById('pid').value = id;
 function esc(s){return s? s.replace(/</g,'&lt;') : ''}
 async function loadPost(){
-  const res = await fetch('/api/posts.php?offset=0&limit=999'); const posts = await res.json();
-  const p = posts.find(x=>x.id===id);
+  const res = await fetch('/api/post_get.php?id='+encodeURIComponent(id)); const p = await res.json();
   const el = document.getElementById('postCard');
-  if(!p){ el.innerHTML='<div class="tag">Not found</div>'; return; }
+  if(!p || p.status==='error'){ el.innerHTML='<div class="tag">Not found</div>'; return; }
   el.innerHTML = `<h3 style="margin:0 0 4px">${esc(p.title)}</h3>
     <div class="meta"><span class="tag"><a href="/user/${esc(p.author||'anon')}">${esc(p.author||'anon')}</a></span><span>·</span><span>${new Date(p.created_at).toLocaleString()}</span></div>
     <p style="margin:10px 0">${esc(p.content)}</p>

--- a/user.php
+++ b/user.php
@@ -31,9 +31,9 @@ else if(!empty($rec['last_seen']) && time()-strtotime($rec['last_seen'])<=90) $b
 const user = <?php echo json_encode($u); ?>;
 function esc(s){return s? s.replace(/</g,'&lt;') : ''}
 async function loadUserPosts(){
-  const res = await fetch('/api/posts.php?offset=0&limit=999'); const posts = await res.json();
+  const res = await fetch('/api/posts_by_user.php?username='+encodeURIComponent(user)); const posts = await res.json();
   const list = document.getElementById('userPosts'); list.innerHTML='';
-  posts.filter(p=>String(p.author).toLowerCase()===user.toLowerCase()).forEach(p=>{
+  posts.forEach(p=>{
     const el = document.createElement('article'); el.className='card';
     el.innerHTML = `<h3 style="margin:0 0 4px"><a href="/post_view.php?id=${encodeURIComponent(p.id)}">${esc(p.title)}</a></h3>
       <div class="meta"><span class="tag">${new Date(p.created_at).toLocaleString()}</span></div>


### PR DESCRIPTION
## Summary
- Add `post_get.php` API to fetch a single post with likes by ID
- Add `posts_by_user.php` API to list posts authored by a given username
- Update `post_view.php` and `user.php` to use new APIs and remove client-side filtering

## Testing
- ✅ `php -l api/post_get.php`
- ✅ `php -l api/posts_by_user.php`
- ✅ `php -l post_view.php`
- ✅ `php -l user.php`


------
https://chatgpt.com/codex/tasks/task_e_68a75a05a348832f89545ef45c5ad6c9