### PR TITLE
Add CSRF protection for forms and APIs

### DIFF
--- a/api/api_bootstrap.php
+++ b/api/api_bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 if(session_status()===PHP_SESSION_NONE){ session_start(); }
+if(empty($_SESSION['csrf_token'])){ $_SESSION['csrf_token']=bin2hex(random_bytes(32)); }
 date_default_timezone_set('UTC');
 $DATA_DIR = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'data';
 if (!file_exists($DATA_DIR)) { @mkdir($DATA_DIR, 0755, true); }
@@ -12,6 +13,8 @@ function write_json($f,$arr){
 }
 function respond($arr){ header('Content-Type: application/json; charset=utf-8'); echo json_encode($arr); exit;}
 function param($key){ return isset($_POST[$key])?trim($_POST[$key]):(isset($_GET[$key])?trim($_GET[$key]):''); }
+function csrf_token(){ return $_SESSION['csrf_token'] ?? ''; }
+function verify_csrf(){ $t=param('csrf_token'); if(!$t || !hash_equals($_SESSION['csrf_token'] ?? '', $t)){ respond(['status'=>'error','message'=>'Invalid CSRF token']); } }
 function current_user(){ return $_SESSION['user'] ?? null; }
 function require_login(){ if(!current_user()){ respond(['status'=>'error','message'=>'Login required']); } }
 ?>

--- a/api/change_password.php
+++ b/api/change_password.php
@@ -1,5 +1,7 @@
 <?php
-require __DIR__.'/api_bootstrap.php'; require_login();
+require __DIR__.'/api_bootstrap.php';
+require_login();
+verify_csrf();
 $u = current_user(); $old = param('oldpass'); $new = param('newpass');
 $users = read_json('users.json');
 if(!isset($users[$u])) respond(['status'=>'error','message'=>'User not found']);

--- a/api/comments_add.php
+++ b/api/comments_add.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__.'/api_bootstrap.php';
+verify_csrf();
 $pid = param('post_id'); $message = param('message'); $author = current_user() ?: (param('author')?:'anon');
 if($pid===''||$message==='') respond(['status'=>'error','message'=>'post_id & message required']);
 $all = read_json('comments.json'); if(!isset($all[$pid])) $all[$pid]=array();

--- a/api/forum_create.php
+++ b/api/forum_create.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__.'/api_bootstrap.php';
+verify_csrf();
 $topic = param('topic'); $message = param('message'); $author = current_user() ?: (param('author')?:'anon');
 if($topic===''||$message==='') respond(['status'=>'error','message'=>'Topic & message required']);
 $topics = read_json('topics.json'); if(!is_array($topics)) $topics=[];

--- a/api/forum_reply.php
+++ b/api/forum_reply.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__.'/api_bootstrap.php';
+verify_csrf();
 $id = param('id'); $message = param('message'); $author = current_user() ?: (param('author')?:'anon');
 if($id===''||$message==='') respond(['status'=>'error','message'=>'id & message required']);
 $topics = read_json('topics.json');

--- a/api/live_chat_post.php
+++ b/api/live_chat_post.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__.'/api_bootstrap.php';
+verify_csrf();
 $msg = param('message'); $author = current_user() ?: (param('author')?:'anon');
 if($msg==='') respond(['status'=>'error','message'=>'message required']);
 $chat = read_json('live_chat.json'); if(!is_array($chat)) $chat=[];

--- a/api/login.php
+++ b/api/login.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__.'/api_bootstrap.php';
+verify_csrf();
 $u = strtolower(param('username')); $p = param('password');
 $users = read_json('users.json');
 if(!isset($users[$u])) respond(['status'=>'error','message'=>'Invalid credentials']);

--- a/api/post_create.php
+++ b/api/post_create.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__.'/api_bootstrap.php';
+verify_csrf();
 $title = param('title'); $content = param('content'); $author = current_user() ?: 'anon';
 if($title===''||$content===''){ respond(['status'=>'error','message'=>'Title & content required'];; }
 $posts = read_json('posts.json'); if(!is_array($posts)) $posts=[];

--- a/api/register.php
+++ b/api/register.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__.'/api_bootstrap.php';
+verify_csrf();
 $u = strtolower(param('newuser')); $p = param('newpass');
 if($u===''||$p===''){ respond(['status'=>'error','message'=>'Username & password required']); }
 if(!preg_match('/^[a-z0-9_\-]{3,20}$/',$u)){ respond(['status'=>'error','message'=>'Username must be 3-20 chars, a-z, 0-9, _, -']); }

--- a/api/request_reset.php
+++ b/api/request_reset.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__.'/api_bootstrap.php';
+verify_csrf();
 $u = strtolower(param('username'));
 $users = read_json('users.json');
 if(!isset($users[$u])) respond(['status'=>'error','message'=>'No such user']);

--- a/api/reset_password.php
+++ b/api/reset_password.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__.'/api_bootstrap.php';
+verify_csrf();
 $u = strtolower(param('username')); $token = param('token'); $new = param('newpass');
 $users = read_json('users.json');
 if(!isset($users[$u])||!isset($users[$u]['reset'])) respond(['status'=>'error','message'=>'Invalid token']);

--- a/api/update_profile.php
+++ b/api/update_profile.php
@@ -1,5 +1,7 @@
 <?php
-require __DIR__.'/api_bootstrap.php'; require_login();
+require __DIR__.'/api_bootstrap.php';
+require_login();
+verify_csrf();
 $u = current_user();
 $users = read_json('users.json');
 if(!isset($users[$u])) respond(['status'=>'error','message'=>'User not found']);

--- a/forum.php
+++ b/forum.php
@@ -2,10 +2,11 @@
 <section class="section"><div class="container">
   <h2>Forum</h2>
   <form class="form" id="topicForm" action="/api/forum_create.php" method="post" style="margin-bottom:14px">
-    <input class="input" type="text" name="topic" placeholder="Topic title" required>
-    <textarea class="textarea" name="message" placeholder="Kick off with your opening message..." required></textarea>
-    <button class="btn primary" type="submit"><i class="fa-solid fa-paper-plane"></i> Start Topic</button>
-  </form>
+      <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+      <input class="input" type="text" name="topic" placeholder="Topic title" required>
+      <textarea class="textarea" name="message" placeholder="Kick off with your opening message..." required></textarea>
+      <button class="btn primary" type="submit"><i class="fa-solid fa-paper-plane"></i> Start Topic</button>
+    </form>
   <table class="table"><thead><tr><th>Topic</th><th>Started by</th><th>Replies</th><th>When</th></tr></thead><tbody id="topicsBody"></tbody></table>
 </div></section>
 <?php include __DIR__.'/partials/footer.php'; ?>

--- a/live.php
+++ b/live.php
@@ -9,11 +9,12 @@
     <div class="card reveal">
       <h3 style="margin:0">Live Chat</h3>
       <ul id="chat" style="list-style:none;padding-left:0;max-height:380px;overflow:auto;margin:12px 0"></ul>
-      <form id="chatForm" class="form" action="/api/live_chat_post.php" method="post">
-        <input class="input" type="text" name="author" placeholder="Name (optional)">
-        <input class="input" type="text" name="message" placeholder="Type a message…" required>
-        <button class="btn primary" type="submit"><i class="fa-regular fa-paper-plane"></i> Send</button>
-      </form>
+        <form id="chatForm" class="form" action="/api/live_chat_post.php" method="post">
+          <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+          <input class="input" type="text" name="author" placeholder="Name (optional)">
+          <input class="input" type="text" name="message" placeholder="Type a message…" required>
+          <button class="btn primary" type="submit"><i class="fa-regular fa-paper-plane"></i> Send</button>
+        </form>
       <div class="actions"><button id="goLive" class="btn primary">Toggle Live</button></div>
     </div>
   </div>

--- a/login.php
+++ b/login.php
@@ -2,20 +2,23 @@
 <section class="section"><div class="container">
   <h2>Login</h2>
   <form id="loginForm" class="form" action="/api/login.php" method="post">
-    <input class="input" type="text" name="username" placeholder="Username" required>
-    <input class="input" type="password" name="password" placeholder="Password" required>
+      <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+      <input class="input" type="text" name="username" placeholder="Username" required>
+      <input class="input" type="password" name="password" placeholder="Password" required>
     <button class="btn primary" type="submit"><i class="fa-solid fa-right-to-bracket"></i> Sign In</button>
   </form>
   <h2 style="margin-top:24px">Register</h2>
   <form id="registerForm" class="form" action="/api/register.php" method="post">
-    <input class="input" type="text" name="newuser" placeholder="New username" required>
-    <input class="input" type="password" name="newpass" placeholder="New password" required>
+      <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+      <input class="input" type="text" name="newuser" placeholder="New username" required>
+      <input class="input" type="password" name="newpass" placeholder="New password" required>
     <button class="btn" type="submit"><i class="fa-solid fa-user-plus"></i> Create Account</button>
   </form>
   <h2 style="margin-top:24px">Forgot Password</h2>
   <form id="resetReq" class="form" action="/api/request_reset.php" method="post">
-    <input class="input" type="text" name="username" placeholder="Your username" required>
-    <button class="btn" type="submit">Get Reset Link</button>
+      <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+      <input class="input" type="text" name="username" placeholder="Your username" required>
+      <button class="btn" type="submit">Get Reset Link</button>
   </form>
   <div class="tag" id="resetLink"></div>
 </div></section>

--- a/partials/header.php
+++ b/partials/header.php
@@ -1,5 +1,5 @@
 <?php
-  if(session_status()===PHP_SESSION_NONE){ session_start(); }
+  require_once __DIR__.'/../api/api_bootstrap.php';
   $active = $active ?? '';
   $me = $_SESSION['user'] ?? null;
 ?><!DOCTYPE html>

--- a/post.php
+++ b/post.php
@@ -2,10 +2,11 @@
 <section class="section"><div class="container">
   <h2>Create Post</h2>
   <form class="form" id="postForm" action="/api/post_create.php" method="post">
-    <input class="input" type="text" name="title" placeholder="Post title" required>
-    <textarea class="textarea" name="content" placeholder="Drop your fire..." required></textarea>
-    <button class="btn primary" type="submit"><i class="fa-solid fa-upload"></i> Publish</button>
-    <div class="tag">Tip: Posts appear instantly on the Home feed.</div>
+      <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+      <input class="input" type="text" name="title" placeholder="Post title" required>
+      <textarea class="textarea" name="content" placeholder="Drop your fire..." required></textarea>
+      <button class="btn primary" type="submit"><i class="fa-solid fa-upload"></i> Publish</button>
+      <div class="tag">Tip: Posts appear instantly on the Home feed.</div>
   </form>
 </div></section>
 <?php include __DIR__.'/partials/footer.php'; ?>

--- a/post_view.php
+++ b/post_view.php
@@ -5,11 +5,12 @@
   <h2 style="margin-top:18px">Comments</h2>
   <div id="comments" class="grid"></div>
   <form id="commentForm" class="form" action="/api/comments_add.php" method="post" style="margin-top:12px">
-    <input type="hidden" name="post_id" id="pid">
-    <input class="input" type="text" name="author" placeholder="Name (optional)">
-    <textarea class="textarea" name="message" placeholder="Write a comment…" required></textarea>
-    <button class="btn primary" type="submit"><i class="fa-regular fa-paper-plane"></i> Send</button>
-  </form>
+      <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+      <input type="hidden" name="post_id" id="pid">
+      <input class="input" type="text" name="author" placeholder="Name (optional)">
+      <textarea class="textarea" name="message" placeholder="Write a comment…" required></textarea>
+      <button class="btn primary" type="submit"><i class="fa-regular fa-paper-plane"></i> Send</button>
+    </form>
 </div></section>
 <?php include __DIR__.'/partials/footer.php'; ?>
 <script>

--- a/reset.php
+++ b/reset.php
@@ -2,11 +2,12 @@
 <section class="section"><div class="container">
   <h2>Reset Password</h2>
   <form id="resetForm" class="form" action="/api/reset_password.php" method="post">
-    <input class="input" type="hidden" name="username" id="u">
-    <input class="input" type="hidden" name="token" id="t">
-    <input class="input" type="password" name="newpass" placeholder="New password" required>
-    <button class="btn primary" type="submit">Reset</button>
-  </form>
+      <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+      <input class="input" type="hidden" name="username" id="u">
+      <input class="input" type="hidden" name="token" id="t">
+      <input class="input" type="password" name="newpass" placeholder="New password" required>
+      <button class="btn primary" type="submit">Reset</button>
+    </form>
 </div></section>
 <?php include __DIR__.'/partials/footer.php'; ?>
 <script>

--- a/settings.php
+++ b/settings.php
@@ -2,7 +2,8 @@
 <section class="section"><div class="container">
   <h2>Settings</h2>
   <form id="profileForm" class="form" action="/api/update_profile.php" method="post" enctype="multipart/form-data">
-    <input class="input" type="text" name="displayname" placeholder="Display Name">
+      <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+      <input class="input" type="text" name="displayname" placeholder="Display Name">
     <textarea class="textarea" name="bio" placeholder="Bio (280 chars max)"></textarea>
     <select class="select" name="theme">
       <option value="dark">Dark</option>
@@ -17,8 +18,9 @@
 
   <h2 style="margin-top:20px">Change Password</h2>
   <form id="passForm" class="form" action="/api/change_password.php" method="post">
-    <input class="input" type="password" name="oldpass" placeholder="Old password" required>
-    <input class="input" type="password" name="newpass" placeholder="New password" required>
+      <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+      <input class="input" type="password" name="oldpass" placeholder="Old password" required>
+      <input class="input" type="password" name="newpass" placeholder="New password" required>
     <button class="btn" type="submit">Change</button>
   </form>
 </div></section>

--- a/thread.php
+++ b/thread.php
@@ -5,10 +5,11 @@
   <h2 style="margin-top:18px">Replies</h2>
   <div id="replies" class="grid"></div>
   <form class="form" id="replyForm" action="/api/forum_reply.php" method="post" style="margin-top:14px">
-    <input type="hidden" name="id" value="<?php echo htmlspecialchars($_GET['id'] ?? '', ENT_QUOTES); ?>">
-    <textarea class="textarea" name="message" placeholder="Reply..." required></textarea>
-    <button class="btn primary" type="submit"><i class="fa-solid fa-reply"></i> Reply</button>
-  </form>
+      <input type="hidden" name="csrf_token" value="<?php echo csrf_token(); ?>">
+      <input type="hidden" name="id" value="<?php echo htmlspecialchars($_GET['id'] ?? '', ENT_QUOTES); ?>">
+      <textarea class="textarea" name="message" placeholder="Reply..." required></textarea>
+      <button class="btn primary" type="submit"><i class="fa-solid fa-reply"></i> Reply</button>
+    </form>
 </div></section>
 <?php include __DIR__.'/partials/footer.php'; ?>
 <script>


### PR DESCRIPTION
## Summary
- Generate and store CSRF tokens in `api_bootstrap.php` with helper functions for validation.
- Embed hidden `csrf_token` fields across site forms (login, posting, settings, comments, forum, etc.).
- Require `verify_csrf()` in corresponding API endpoints to reject invalid requests.

## Testing
- `php -l api/api_bootstrap.php`
- `php -l api/login.php`
- `php -l api/update_profile.php`
- `php -l api/change_password.php`
- `php -l api/post_create.php` *(fails: unexpected token)*
- `php -l api/register.php` *(fails: unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a75a091d5c832f9a72da4f1d08724d